### PR TITLE
Support inheriting TOML/JSON files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "datalab"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
   {name = "Nick Ulle", email = "nick.ulle@gmail.com"},
 ]

--- a/src/datalab/utilities/__init__.py
+++ b/src/datalab/utilities/__init__.py
@@ -1,0 +1,6 @@
+"""This is the `datalab` package, a namespace package developed by the UC Davis
+DataLab to support our data science research projects.
+"""
+
+__version__ = "0.3.0"
+__author__ = "Nick Ulle"

--- a/src/datalab/utilities/cli.py
+++ b/src/datalab/utilities/cli.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 import datalab.utilities.datetime as dt
 import datalab.utilities.io as io
-import datalab.utilities.maptools as maptools
+import datalab.utilities.dicttools as dicttools
 
 
 def provide_toml_interface(
@@ -52,7 +52,7 @@ def provide_toml_interface(
 
     if format_keys is not None:
         format_keys = {k: config.get(k, "") for k in format_keys}
-        config = maptools.recursive_format(
+        config = dicttools.recursive_format(
             config,
             date = dt.iso_date_now(),
             datetime = dt.iso_datetime_now(),

--- a/src/datalab/utilities/cli.py
+++ b/src/datalab/utilities/cli.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 import datalab.utilities.datetime as dt
 import datalab.utilities.io as io
+import datalab.utilities.maptools as maptools
 
 
 def provide_toml_interface(
@@ -51,7 +52,7 @@ def provide_toml_interface(
 
     if format_keys is not None:
         format_keys = {k: config.get(k, "") for k in format_keys}
-        config = io.recursive_format(
+        config = maptools.recursive_format(
             config,
             date = dt.iso_date_now(),
             datetime = dt.iso_datetime_now(),

--- a/src/datalab/utilities/dicttools.py
+++ b/src/datalab/utilities/dicttools.py
@@ -1,11 +1,11 @@
-"""Functions for working with mappings.
+"""Functions for working with dicts and other key-value data structures.
 """
 
 from typing import Any
 
 
 def recursive_update(older: dict, newer: dict) -> dict:
-    """Recursively update older mappings with newer mappings.
+    """Recursively update a dict and its sub-dicts with new key-value pairs.
 
     Note that this function does not recurse into lists (their key is updated
     without examining their elements).

--- a/src/datalab/utilities/io.py
+++ b/src/datalab/utilities/io.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import tomllib
 from typing import Any
 
-import datalab.utilities.maptools as maptools
+import datalab.utilities.dicttools as dicttools
 
 
 def read_api_key(path: str | Path) -> str:
@@ -58,7 +58,7 @@ def read_toml(path: str | Path, inherit: bool = False) -> dict:
                     " inherit from a different file."
                 )
 
-        result = maptools.recursive_update(inherited, result)
+        result = dicttools.recursive_update(inherited, result)
 
     return result
 

--- a/src/datalab/utilities/io.py
+++ b/src/datalab/utilities/io.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import tomllib
 from typing import Any
 
+import datalab.utilities.maptools as maptools
+
 
 def read_api_key(path: str | Path) -> str:
     """Read an API key or authentication token from a file.
@@ -23,20 +25,42 @@ def read_api_key(path: str | Path) -> str:
         return f.readline().strip()
 
 
-def read_toml(path: str | Path) -> dict:
+def read_toml(path: str | Path, inherit: bool = False) -> dict:
     """Read a TOML file.
 
     Parameters
     ----------
     path
         Path to the TOML file to read.
+    inherit
+        If True, the TOML file can inherit settings from another TOML file
+        whose path is specified in a top-level `inherit` key.
 
     Returns
     -------
     The contents of the TOML file.
     """
     with open(path, "rb") as f:
-        return tomllib.load(f)
+        result = tomllib.load(f)
+
+    if inherit and "inherit" in result:
+        inherit_path = Path(result["inherit"])
+        if not inherit_path.is_absolute():
+            # So `inherit_path` is relative to `path`.
+            inherit_path = Path(path).parent / inherit_path
+
+        with open(inherit_path, "rb") as f:
+            inherited = tomllib.load(f)
+            if "inherit" in inherited:
+                raise RuntimeError(
+                    f"The inherited file ('{inherit_path}') also has an"
+                    " `inherit` key, which is not allowed. Remove the key or"
+                    " inherit from a different file."
+                )
+
+        result = maptools.recursive_update(inherited, result)
+
+    return result
 
 
 def recursive_format(obj: dict, **kwargs):

--- a/src/datalab/utilities/io.py
+++ b/src/datalab/utilities/io.py
@@ -63,32 +63,6 @@ def read_toml(path: str | Path, inherit: bool = False) -> dict:
     return result
 
 
-def recursive_format(obj: dict, **kwargs):
-    """Recurse through a JSON- or TOML-like object, formatting all strings
-    found.
-
-    Parameters
-    ----------
-    obj
-        The object to recurse through.
-    **kwargs
-        Arguments to `str.format`.
-
-    Returns
-    -------
-    An object with the same shape as `obj` and all strings formatted.
-    """
-    match obj:
-        case dict():
-            return {k: recursive_format(v, **kwargs) for k, v in obj.items()}
-        case list():
-            return [recursive_format(x, **kwargs) for x in obj]
-        case str():
-            return obj.format(**kwargs)
-        case _:
-            return obj
-
-
 def read_json(path: str | Path) -> Any:
     """Read a JSON file.
 

--- a/src/datalab/utilities/maptools.py
+++ b/src/datalab/utilities/maptools.py
@@ -1,0 +1,27 @@
+"""Functions for working with mappings.
+"""
+
+import collections
+
+
+def recursive_update(older, newer):
+    """Recursively update older mappings with newer mappings.
+
+    Note that lists are replaced rather than combined.
+
+    Parameters
+    ----------
+    older
+        The mapping to update.
+    newer
+        The mapping to use to update the older mapping.
+    """
+    MM = collections.abc.MutableMapping
+    result = older.copy()
+    for k, v in newer.items():
+        if isinstance(v, MM) and isinstance(result.get(k), MM):
+            result[k] = recursive_update(result[k], v)
+        else:
+            result[k] = v
+
+    return result


### PR DESCRIPTION
This PR changes the `read_toml` and `read_json` functions so that when they read a file, they can optionally read a second _inherited_ file with default values for missing keys. This addresses #1.

This behavior is only enabled when the parameter `inherit` is set to `True` (by default it is `False`). The inherited file must be specified with an `inherit` key at the top level of the read file. The functions raise an error if the inherited file also contains an `inherit` key at the top level.

This PR also adds standard Python package metadata such as `__version__`.